### PR TITLE
Added .p-fileupload-highlight class missing

### DIFF
--- a/theme-base/components/file/_fileupload.scss
+++ b/theme-base/components/file/_fileupload.scss
@@ -27,7 +27,6 @@
 
         &.p-fileupload-highlight {
             border-color: $primaryColor;
-            border-width: 2px;
             border-style: dashed;
             background-color: $highlightBg;
         }

--- a/theme-base/components/file/_fileupload.scss
+++ b/theme-base/components/file/_fileupload.scss
@@ -24,6 +24,13 @@
         color: $panelContentTextColor;
         border-bottom-right-radius: $borderRadius;
         border-bottom-left-radius: $borderRadius;
+
+        &.p-fileupload-highlight {
+            border-color: $primaryColor;
+            border-width: 2px;
+            border-style: dashed;
+            background-color: $highlightBg;
+        }
     }
 
     .p-progressbar {


### PR DESCRIPTION
Fixes #50 

Added  .p-fileupload-highlight class missing to solve this issue: https://github.com/primefaces/primeng/issues/13306

I have follow the same idea like:
PrimeReact: https://github.com/primefaces/primereact-sass-theme/pull/28
PrimeVue: https://github.com/primefaces/primevue-sass-theme/pull/14

## BEFORE
when I'm trying to drag over my file in the component (nothing was happening)

![problem fileupload](https://github.com/primefaces/primeng/assets/19764334/85430299-7f81-4171-8533-6bc3c48bca08)

## AFTER
![fixed fileupload](https://github.com/primefaces/primeng/assets/19764334/a77161de-e688-40cc-b0c9-9d0555c19f67)