### PR TITLE
AutoComplete: Fixed alignment

### DIFF
--- a/theme-base/components/input/_autocomplete.scss
+++ b/theme-base/components/input/_autocomplete.scss
@@ -42,6 +42,7 @@
             border-radius: $borderRadius;
 
             .p-autocomplete-token-icon {
+                display: flex;
                 margin-left: $inlineSpacing;
             }
         }


### PR DESCRIPTION
Adding this line, fix the alignment issue https://github.com/primefaces/primeng/issues/13532.

### CURRENTLY
![autocomplete problem](https://github.com/primefaces/primeng-sass-theme/assets/19764334/e4e43e0d-ac5f-4426-844f-b00a5dadbb9f)

### AFTER SOLUTION
![autocomplete fixed](https://github.com/primefaces/primeng-sass-theme/assets/19764334/5592d5c0-a4dc-47e2-a89c-8fd13819f573)
