### PR TITLE
Datatable: Fixed outline-offset

### DIFF
--- a/theme-base/components/data/_datatable.scss
+++ b/theme-base/components/data/_datatable.scss
@@ -123,7 +123,7 @@
 
             &:focus {
                 outline: 0.15rem solid $focusOutlineColor;
-                outline-offset: 0.15rem;
+                outline-offset: -0.15rem;
             }
 
             &.p-highlight {


### PR DESCRIPTION
Fixes #49 

Fixed `outline-offset`. Now the value is like in the PrimeVue Library

You can see the issue in PrimeNG Repo: https://github.com/primefaces/primeng/issues/13617