### PR TITLE
fix: #13650 || showClear css selector class mismatch issue solve

### DIFF
--- a/theme-base/components/input/_calendar.scss
+++ b/theme-base/components/input/_calendar.scss
@@ -245,7 +245,7 @@ p-calendar.p-calendar-clearable {
     }
 }
 
-p-calendar.p-calendar-clearable.p-calendar-w-btn {
+p-calendar.p-calendar-clearable .p-calendar-w-btn {
     .p-calendar-clear-icon {
         color: $inputIconColor;
         right: $buttonIconOnlyWidth + nth($inputPadding, 2);


### PR DESCRIPTION
Fixed calendar clear icon not showing when icon show. Here was CSS selector class mismatch.

You can see the issue in PrimeNG Repo: https://github.com/primefaces/primeng/issues/13650