### PR TITLE
Editor: Fix background-color in dark mode themes

### DIFF
--- a/theme-base/components/input/_editor.scss
+++ b/theme-base/components/input/_editor.scss
@@ -47,7 +47,7 @@
                     }
 
                     .ql-picker-options {
-                        background: $inputOverlayBg;
+                        background: $inputOverlayBg !important;
                         border:$inputOverlayBorder;
                         box-shadow:$inputOverlayShadow;
                         border-radius: $borderRadius;


### PR DESCRIPTION
Fix #56

I added the `!important` because the styles were being taken by Quill Editor and I cannot remove the line of that file because is imported from `node_modules` in PrimeNG project: 

![image](https://github.com/primefaces/primeng-sass-theme/assets/19764334/bfe5e00a-bd2d-49ff-a6ce-dee41ed630b0)

For this reason, I solved the problem in this way. If you know something better, let me know :)

## CURRENTLY
![problem editor PRIMENG](https://github.com/primefaces/primeng-sass-theme/assets/19764334/85c25510-12b1-457a-b8b6-5ffddd6d3150)

## AFTER SOLUTION
![fix editor PRIMENG](https://github.com/primefaces/primeng-sass-theme/assets/19764334/e6817e33-d775-4323-b276-e3b3081f4701)
