### PR TITLE
resolves #62 publish themes to npmjs.org

### DIFF
--- a/.github/workflows/publish-to-npmjs.yaml
+++ b/.github/workflows/publish-to-npmjs.yaml
@@ -1,0 +1,19 @@
+# see https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+name: Publish Package to npmjs
+on:
+  release:
+    types:
+      - published
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,24 +1,28 @@
 {
-    "name": "primeng-sass-theme",
-    "version": "17.12.0",
-    "description": "PrimeNG Sass Theme",
-    "homepage": "https://primeng.org/",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/primefaces/primeng-sass-theme.git"
-    },
-    "keywords": [
-        "primeng",
-        "angular",
-        "ui framework",
-        "component framework",
-        "ui library",
-        "component library",
-        "material",
-        "bootstrap"
-    ],
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/primefaces/primeng-sass-theme/issues"
-    }
+  "name": "primeng-sass-theme",
+  "version": "17.12.0",
+  "description": "PrimeNG Sass Theme",
+  "homepage": "https://primeng.org/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/primefaces/primeng-sass-theme.git"
+  },
+  "keywords": [
+    "primeng",
+    "angular",
+    "ui framework",
+    "component framework",
+    "ui library",
+    "component library",
+    "material",
+    "bootstrap"
+  ],
+  "license": "MIT",
+  "files": [
+    "themes/**/*",
+    "theme-base/**/.*"
+  ],
+  "bugs": {
+    "url": "https://github.com/primefaces/primeng-sass-theme/issues"
+  }
 }


### PR DESCRIPTION
resolves #62

setup to automatically publish the themes as an npm package on npmjs.org
todo provide the secret NPM_TOKEN