### PR TITLE
Fix mytheme hard coded values

### DIFF
--- a/themes/mytheme/_variables.scss
+++ b/themes/mytheme/_variables.scss
@@ -32,8 +32,8 @@ $colors: (
 @import './variables/_misc';
 
 :root {
-    font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    --font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-family:#{$fontFamily};
+    --font-family:#{$fontFamily};
     --surface-a:#ffffff;
     --surface-b:#f8f9fa;
     --surface-c:#e9ecef;
@@ -42,8 +42,8 @@ $colors: (
     --surface-f:#ffffff;
     --text-color:#495057;
     --text-color-secondary:#6c757d;
-    --primary-color:#2196F3;
-    --primary-color-text:#ffffff;
+    --primary-color:#{$primaryColor};
+    --primary-color-text:#{$primaryTextColor};
     --surface-0: #ffffff;
     --surface-50: #FAFAFA;
     --surface-100: #F5F5F5;


### PR DESCRIPTION
Some values in _variables.scss are hardcoded instead of using existing variables. It is confusing to have variables which have not the intended effect because they are not used everywhere.